### PR TITLE
Fix 'Cannot find module ‘puppeteer/DeviceDescriptors’' error

### DIFF
--- a/js/screen.js
+++ b/js/screen.js
@@ -1,5 +1,5 @@
 const puppeteer = require('puppeteer');
-const devices = require('puppeteer/DeviceDescriptors');
+const devices = puppeteer.devices;
 const fs = require('fs');
 
 (async () => {


### PR DESCRIPTION
If you are using puppeteer version >= 5.0 you would get following error:

`Error: Cannot find module ‘puppeteer/DeviceDescriptors’`

I adjusted the line causing the error.

_btw. Thanks for this cool project, I'm using it instead of EyeWitness_ 👍